### PR TITLE
Fix negative temperature readings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ A Rust DS18B20 temperature sensor driver for [embedded-hal](https://github.com/r
 """
 
 [dependencies]
-one-wire-bus = "0.1.1"
-embedded-hal = {version="0.2.3", features=["unproven"]}
+one-wire-bus = {git = "https://github.com/rednaz1337/one-wire-bus"}
+embedded-hal = {version="1.0.0-alpha.10"}
+embedded-hal-compat = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ A Rust DS18B20 temperature sensor driver for [embedded-hal](https://github.com/r
 [dependencies]
 one-wire-bus = {git = "https://github.com/rednaz1337/one-wire-bus"}
 embedded-hal = {version="1.0.0-alpha.10"}
-embedded-hal-compat = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ A Rust DS18B20 temperature sensor driver for [embedded-hal](https://github.com/r
 """
 
 [dependencies]
-one-wire-bus = {git = "https://github.com/rednaz1337/one-wire-bus"}
-embedded-hal = {version="1.0.0-alpha.10"}
+one-wire-bus = {path = "../one-wire-bus"}
+embedded-hal = {version="1"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![no_std]
 
-//! # Test Test
+use embedded_hal_compat::{ForwardCompat, ReverseCompat};
 
-use embedded_hal::blocking::delay::DelayUs;
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embedded_hal::delay::DelayUs;
+use embedded_hal::digital::{InputPin, OutputPin};
 use one_wire_bus::{self, Address, OneWire, OneWireError, OneWireResult};
 
 pub const FAMILY_CODE: u8 = 0x28;
@@ -56,26 +56,26 @@ impl Ds18b20 {
     pub fn start_temp_measurement<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs<u16>,
+        delay: &mut impl DelayUs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
         T: OutputPin<Error = E>,
     {
-        onewire.send_command(commands::CONVERT_TEMP, Some(&self.address), delay)?;
+        onewire.send_command(commands::CONVERT_TEMP, Some(&self.address), delay.reverse())?;
         Ok(())
     }
 
     pub fn read_data<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs<u16>,
+        delay: &mut impl DelayUs,
     ) -> OneWireResult<SensorData, E>
     where
         T: InputPin<Error = E>,
         T: OutputPin<Error = E>,
     {
-        let data = read_data(&self.address, onewire, delay)?;
+        let data = read_data(&self.address, onewire, delay.reverse())?;
         Ok(data)
     }
 
@@ -85,7 +85,7 @@ impl Ds18b20 {
         alarm_temp_high: i8,
         resolution: Resolution,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs<u16>,
+        delay: &mut impl DelayUs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
@@ -101,7 +101,7 @@ impl Ds18b20 {
     pub fn save_to_eeprom<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs<u16>,
+        delay: &mut impl DelayUs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
@@ -113,7 +113,7 @@ impl Ds18b20 {
     pub fn recall_from_eeprom<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs<u16>,
+        delay: &mut impl DelayUs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
@@ -126,7 +126,7 @@ impl Ds18b20 {
 /// Starts a temperature measurement for all devices on this one-wire bus, simultaneously
 pub fn start_simultaneous_temp_measurement<T, E>(
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayUs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -141,7 +141,7 @@ where
 /// Read the contents of the EEPROM config to the scratchpad for all devices simultaneously.
 pub fn simultaneous_recall_from_eeprom<T, E>(
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayUs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -153,7 +153,7 @@ where
 /// Read the config contents of the scratchpad memory to the EEPROMfor all devices simultaneously.
 pub fn simultaneous_save_to_eeprom<T, E>(
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayUs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -165,7 +165,7 @@ where
 pub fn read_scratchpad<T, E>(
     address: &Address,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayUs,
 ) -> OneWireResult<[u8; 9], E>
 where
     T: InputPin<Error = E>,
@@ -183,7 +183,7 @@ where
 fn read_data<T, E>(
     address: &Address,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayUs,
 ) -> OneWireResult<SensorData, E>
 where
     T: InputPin<Error = E>,
@@ -214,7 +214,7 @@ where
 fn recall_from_eeprom<T, E>(
     address: Option<&Address>,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayUs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -235,7 +235,7 @@ where
 fn save_to_eeprom<T, E>(
     address: Option<&Address>,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayUs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-use embedded_hal_compat::{ForwardCompat, ReverseCompat};
-
 use embedded_hal::delay::DelayUs;
 use embedded_hal::digital::{InputPin, OutputPin};
 use one_wire_bus::{self, Address, OneWire, OneWireError, OneWireResult};
@@ -62,7 +60,7 @@ impl Ds18b20 {
         T: InputPin<Error = E>,
         T: OutputPin<Error = E>,
     {
-        onewire.send_command(commands::CONVERT_TEMP, Some(&self.address), delay.reverse())?;
+        onewire.send_command(commands::CONVERT_TEMP, Some(&self.address), delay)?;
         Ok(())
     }
 
@@ -75,7 +73,7 @@ impl Ds18b20 {
         T: InputPin<Error = E>,
         T: OutputPin<Error = E>,
     {
-        let data = read_data(&self.address, onewire, delay.reverse())?;
+        let data = read_data(&self.address, onewire, delay)?;
         Ok(data)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,7 @@ where
     } else {
         return Err(OneWireError::CrcMismatch);
     };
-    let raw_temp = u16::from_le_bytes([scratchpad[0], scratchpad[1]]);
+    let raw_temp = i16::from_le_bytes([scratchpad[0], scratchpad[1]]);
     let temperature = match resolution {
         Resolution::Bits12 => (raw_temp as f32) / 16.0,
         Resolution::Bits11 => (raw_temp as f32) / 8.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use embedded_hal::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::{InputPin, OutputPin};
 use one_wire_bus::{self, Address, OneWire, OneWireError, OneWireResult};
 
@@ -54,7 +54,7 @@ impl Ds18b20 {
     pub fn start_temp_measurement<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs,
+        delay: &mut impl DelayNs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
@@ -67,7 +67,7 @@ impl Ds18b20 {
     pub fn read_data<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs,
+        delay: &mut impl DelayNs,
     ) -> OneWireResult<SensorData, E>
     where
         T: InputPin<Error = E>,
@@ -83,7 +83,7 @@ impl Ds18b20 {
         alarm_temp_high: i8,
         resolution: Resolution,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs,
+        delay: &mut impl DelayNs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
@@ -99,7 +99,7 @@ impl Ds18b20 {
     pub fn save_to_eeprom<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs,
+        delay: &mut impl DelayNs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
@@ -111,7 +111,7 @@ impl Ds18b20 {
     pub fn recall_from_eeprom<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs,
+        delay: &mut impl DelayNs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
@@ -124,7 +124,7 @@ impl Ds18b20 {
 /// Starts a temperature measurement for all devices on this one-wire bus, simultaneously
 pub fn start_simultaneous_temp_measurement<T, E>(
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -139,7 +139,7 @@ where
 /// Read the contents of the EEPROM config to the scratchpad for all devices simultaneously.
 pub fn simultaneous_recall_from_eeprom<T, E>(
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -151,7 +151,7 @@ where
 /// Read the config contents of the scratchpad memory to the EEPROMfor all devices simultaneously.
 pub fn simultaneous_save_to_eeprom<T, E>(
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -163,7 +163,7 @@ where
 pub fn read_scratchpad<T, E>(
     address: &Address,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<[u8; 9], E>
 where
     T: InputPin<Error = E>,
@@ -181,7 +181,7 @@ where
 fn read_data<T, E>(
     address: &Address,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<SensorData, E>
 where
     T: InputPin<Error = E>,
@@ -212,7 +212,7 @@ where
 fn recall_from_eeprom<T, E>(
     address: Option<&Address>,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -233,7 +233,7 @@ where
 fn save_to_eeprom<T, E>(
     address: Option<&Address>,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -22,7 +22,7 @@ impl Resolution {
     /// Blocks for the amount of time required to finished measuring temperature
     /// using this resolution
     pub fn delay_for_measurement_time(&self, delay: &mut impl DelayUs) {
-        delay.delay_ms(self.max_measurement_time_millis());
+        delay.delay_ms(self.max_measurement_time_millis().into());
     }
 
     pub(crate) fn from_config_register(config: u8) -> Option<Resolution> {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,4 +1,4 @@
-use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::delay::DelayUs;
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
@@ -21,7 +21,7 @@ impl Resolution {
 
     /// Blocks for the amount of time required to finished measuring temperature
     /// using this resolution
-    pub fn delay_for_measurement_time(&self, delay: &mut impl DelayMs<u16>) {
+    pub fn delay_for_measurement_time(&self, delay: &mut impl DelayUs) {
         delay.delay_ms(self.max_measurement_time_millis());
     }
 

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,4 +1,4 @@
-use embedded_hal::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
@@ -21,7 +21,7 @@ impl Resolution {
 
     /// Blocks for the amount of time required to finished measuring temperature
     /// using this resolution
-    pub fn delay_for_measurement_time(&self, delay: &mut impl DelayUs) {
+    pub fn delay_for_measurement_time(&self, delay: &mut impl DelayNs) {
         delay.delay_ms(self.max_measurement_time_millis().into());
     }
 


### PR DESCRIPTION
Using an i16 instead of u16 the library can correctly read negative temperatures.