### PR TITLE
Update to embedded-hal 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ A Rust DS18B20 temperature sensor driver for [embedded-hal](https://github.com/r
 """
 
 [dependencies]
-one-wire-bus.git = "https://github.com/elwerene/one-wire-bus.git"
+one-wire-bus.git = "https://github.com/daniel-larsen/one-wire-bus.git"
 embedded-hal = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,13 @@ authors = ["Nathan Fox <fuchsnj@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/fuchsnj/ds18b20"
-keywords = ["onewire", "embedded-hal-driver", "ds18b20", "temperature", "sensor"]
+keywords = [
+    "onewire",
+    "embedded-hal-driver",
+    "ds18b20",
+    "temperature",
+    "sensor",
+]
 readme = "README.md"
 categories = ["embedded", "hardware-support", "no-std"]
 description = """
@@ -13,5 +19,5 @@ A Rust DS18B20 temperature sensor driver for [embedded-hal](https://github.com/r
 """
 
 [dependencies]
-one-wire-bus = "0.1.1"
-embedded-hal = {version="0.2.3", features=["unproven"]}
+one-wire-bus.path = "../one-wire-bus"
+embedded-hal = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ A Rust DS18B20 temperature sensor driver for [embedded-hal](https://github.com/r
 """
 
 [dependencies]
-one-wire-bus.path = "../one-wire-bus"
+one-wire-bus.git = "https://github.com/elwerene/one-wire-bus.git"
 embedded-hal = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::{InputPin, OutputPin};
-use one_wire_bus::{self, Address, OneWire, OneWireError, OneWireResult};
+use one_wire_bus::{Address, OneWire, OneWireError, OneWireResult};
 
 pub const FAMILY_CODE: u8 = 0x28;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,7 @@ where
     } else {
         return Err(OneWireError::CrcMismatch);
     };
-    let raw_temp = u16::from_le_bytes([scratchpad[0], scratchpad[1]]);
+    let raw_temp = i16::from_le_bytes([scratchpad[0], scratchpad[1]]);
     let temperature = match resolution {
         Resolution::Bits12 => (raw_temp as f32) / 16.0,
         Resolution::Bits11 => (raw_temp as f32) / 8.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 
 //! # Test Test
 
-use embedded_hal::blocking::delay::DelayUs;
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embedded_hal::delay::DelayNs;
+use embedded_hal::digital::{InputPin, OutputPin};
 use one_wire_bus::{self, Address, OneWire, OneWireError, OneWireResult};
 
 pub const FAMILY_CODE: u8 = 0x28;
@@ -56,7 +56,7 @@ impl Ds18b20 {
     pub fn start_temp_measurement<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs<u16>,
+        delay: &mut impl DelayNs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
@@ -69,7 +69,7 @@ impl Ds18b20 {
     pub fn read_data<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs<u16>,
+        delay: &mut impl DelayNs,
     ) -> OneWireResult<SensorData, E>
     where
         T: InputPin<Error = E>,
@@ -85,7 +85,7 @@ impl Ds18b20 {
         alarm_temp_high: i8,
         resolution: Resolution,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs<u16>,
+        delay: &mut impl DelayNs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
@@ -101,7 +101,7 @@ impl Ds18b20 {
     pub fn save_to_eeprom<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs<u16>,
+        delay: &mut impl DelayNs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
@@ -113,7 +113,7 @@ impl Ds18b20 {
     pub fn recall_from_eeprom<T, E>(
         &self,
         onewire: &mut OneWire<T>,
-        delay: &mut impl DelayUs<u16>,
+        delay: &mut impl DelayNs,
     ) -> OneWireResult<(), E>
     where
         T: InputPin<Error = E>,
@@ -126,7 +126,7 @@ impl Ds18b20 {
 /// Starts a temperature measurement for all devices on this one-wire bus, simultaneously
 pub fn start_simultaneous_temp_measurement<T, E>(
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -141,7 +141,7 @@ where
 /// Read the contents of the EEPROM config to the scratchpad for all devices simultaneously.
 pub fn simultaneous_recall_from_eeprom<T, E>(
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -153,7 +153,7 @@ where
 /// Read the config contents of the scratchpad memory to the EEPROMfor all devices simultaneously.
 pub fn simultaneous_save_to_eeprom<T, E>(
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -165,7 +165,7 @@ where
 pub fn read_scratchpad<T, E>(
     address: &Address,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<[u8; 9], E>
 where
     T: InputPin<Error = E>,
@@ -183,7 +183,7 @@ where
 fn read_data<T, E>(
     address: &Address,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<SensorData, E>
 where
     T: InputPin<Error = E>,
@@ -214,7 +214,7 @@ where
 fn recall_from_eeprom<T, E>(
     address: Option<&Address>,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,
@@ -225,7 +225,7 @@ where
     // wait for the recall to finish (up to 10ms)
     let max_retries = (10000 / one_wire_bus::READ_SLOT_DURATION_MICROS) + 1;
     for _ in 0..max_retries {
-        if onewire.read_bit(delay)? == true {
+        if onewire.read_bit(delay)? {
             return Ok(());
         }
     }
@@ -235,7 +235,7 @@ where
 fn save_to_eeprom<T, E>(
     address: Option<&Address>,
     onewire: &mut OneWire<T>,
-    delay: &mut impl DelayUs<u16>,
+    delay: &mut impl DelayNs,
 ) -> OneWireResult<(), E>
 where
     T: InputPin<Error = E>,

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,4 +1,4 @@
-use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::delay::DelayNs;
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
@@ -10,7 +10,7 @@ pub enum Resolution {
 }
 
 impl Resolution {
-    pub fn max_measurement_time_millis(&self) -> u16 {
+    pub fn max_measurement_time_millis(&self) -> u32 {
         match self {
             Resolution::Bits9 => 94,
             Resolution::Bits10 => 188,
@@ -21,7 +21,7 @@ impl Resolution {
 
     /// Blocks for the amount of time required to finished measuring temperature
     /// using this resolution
-    pub fn delay_for_measurement_time(&self, delay: &mut impl DelayMs<u16>) {
+    pub fn delay_for_measurement_time(&self, delay: &mut impl DelayNs) {
         delay.delay_ms(self.max_measurement_time_millis());
     }
 
@@ -35,7 +35,7 @@ impl Resolution {
         }
     }
 
-    pub(crate) fn to_config_register(&self) -> u8 {
-        *self as u8
+    pub(crate) fn to_config_register(self) -> u8 {
+        self as u8
     }
 }


### PR DESCRIPTION
Uses the fork https://github.com/daniel-larsen/one-wire-bus of `one-wire-bus` for now and can be updated to a newer version of `one-wire-bus` once https://github.com/fuchsnj/one-wire-bus/pull/5 is merged.